### PR TITLE
Fix la_pop startup wait and sync statements

### DIFF
--- a/la_pop/server/main.lua
+++ b/la_pop/server/main.lua
@@ -4,7 +4,8 @@ local patrolStarted = false
 AddEventHandler('onResourceStart', function(res)
     if res == GetCurrentResourceName() then
         print('[LA_POPULATION] Resource started, syncing all players...')
-        Wait(2000) SyncNPCsToAll()
+        Wait(2000)
+        SyncNPCsToAll()
     end
 end)
 


### PR DESCRIPTION
## Summary
- split the startup Wait and SyncNPCsToAll calls into separate statements to avoid syntax errors

## Testing
- ⚠️ `lua -p la_pop/server/main.lua` *(fails: command not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69124d415d7483228cc5f51f488bf741)