### PR TITLE
Hash NPC models before spawning

### DIFF
--- a/la_pop/client/npc_manager.lua
+++ b/la_pop/client/npc_manager.lua
@@ -18,8 +18,9 @@ end
 RegisterNetEvent('la_population:spawnNPC', function(id, data)
     if data.vehicle then return end
     if NPCs[id] and DoesEntityExist(NPCs[id]) then DeletePed(NPCs[id]) end
-    RequestModel(data.model); while not HasModelLoaded(data.model) do Wait(0) end
-    local ped = CreatePed(4, data.model, data.coords.x, data.coords.y, data.coords.z, data.heading, true, true)
+    local modelHash = joaat(data.model)
+    RequestModel(modelHash); while not HasModelLoaded(modelHash) do Wait(0) end
+    local ped = CreatePed(4, modelHash, data.coords.x, data.coords.y, data.coords.z, data.heading, true, true)
     SetEntityAsMissionEntity(ped, true, true)
     SetEntityInvincible(ped, true)
     SetBlockingOfNonTemporaryEvents(ped, true)
@@ -61,13 +62,16 @@ end)
 -- PATROL UNIT
 RegisterNetEvent('la_population:startPatrol', function(id, data)
     if patrolVehicles[id] then TriggerEvent('la_population:removeNPC', id) end
-    RequestModel(data.model); RequestModel(data.partner); RequestModel(data.vehicle)
-    while not HasModelLoaded(data.model) or not HasModelLoaded(data.partner) or not HasModelLoaded(data.vehicle) do Wait(0) end
-    local veh = CreateVehicle(data.vehicle, data.coords.x, data.coords.y, data.coords.z, data.heading, true, false)
+    local driverModel = joaat(data.model)
+    local partnerModel = joaat(data.partner)
+    local vehicleModel = joaat(data.vehicle)
+    RequestModel(driverModel); RequestModel(partnerModel); RequestModel(vehicleModel)
+    while not HasModelLoaded(driverModel) or not HasModelLoaded(partnerModel) or not HasModelLoaded(vehicleModel) do Wait(0) end
+    local veh = CreateVehicle(vehicleModel, data.coords.x, data.coords.y, data.coords.z, data.heading, true, false)
     SetVehicleOnGroundProperly(veh)
     SetVehicleEngineOn(veh, true, true, false)
-    local driver = CreatePedInsideVehicle(veh, 4, data.model, -1, true, true)
-    local passenger = CreatePedInsideVehicle(veh, 4, data.partner, 0, true, true)
+    local driver = CreatePedInsideVehicle(veh, 4, driverModel, -1, true, true)
+    local passenger = CreatePedInsideVehicle(veh, 4, partnerModel, 0, true, true)
     SetEntityInvincible(driver, true); SetEntityInvincible(passenger, true)
     SetBlockingOfNonTemporaryEvents(driver, true); SetBlockingOfNonTemporaryEvents(passenger, true)
     patrolVehicles[id] = { vehicle = veh, driver = driver, passenger = passenger, route = data.patrolRoute }


### PR DESCRIPTION
## Summary
- hash static NPC models before requesting and spawning
- hash patrol unit driver, partner, and vehicle models before native calls to ensure proper spawning

## Testing
- not run (environment only provides static analysis)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69124dfe0e288322a39aba0c40b2b535)