### PR TITLE
Replace SetInterval cleanup with thread loop

### DIFF
--- a/la_asset_registry/la_asset_registry.lua
+++ b/la_asset_registry/la_asset_registry.lua
@@ -237,12 +237,15 @@ exports('AddJobWhitelist', function(name)
     table.insert(Config.WhitelistedJobs, name)
 end)
 
--- Cleanup old block cache
-SetInterval(function()
-    local now = GetGameTimer()
-    for model, time in pairs(recentlyBlocked) do
-        if now - time > 300000 then
-            recentlyBlocked[model] = nil
+CreateThread(function()
+    while true do
+        Wait(300000)
+
+        local now = GetGameTimer()
+        for model, time in pairs(recentlyBlocked) do
+            if now - time > 300000 then
+                recentlyBlocked[model] = nil
+            end
         end
     end
-end, 300000)
+end)


### PR DESCRIPTION
## Summary
- replace the unsupported SetInterval call with a CreateThread loop that periodically prunes the recentlyBlocked cache
- preserve the 5 minute cleanup cadence so stale entries are cleared as before

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69124e6b4ff483229a090e2baf72e4b6)